### PR TITLE
fix Blocking causes zero result runs

### DIFF
--- a/src/routes/category-search.ts
+++ b/src/routes/category-search.ts
@@ -28,6 +28,10 @@ export const handleCategorySearch = async ({
 
     const $ = await parseWithCheerio();
 
+    if ($('div.main-content').length === 0) {
+        throw new Error('No longer on the search page');
+    }
+
     await enqueueLinks({
         selector: 'tbody[id*="content"] td[class*="name"] a',
         label: LABELS.PRODUCT_PAGE,

--- a/src/routes/global-search.ts
+++ b/src/routes/global-search.ts
@@ -10,6 +10,10 @@ export const handleGlobalSearch = async ({ page, request, log, parseWithCheerio,
     await page.waitForLoadState('load');
     const $ = await parseWithCheerio();
 
+    if ($('section.main-content').length === 0) {
+        throw new Error('No longer on the search page');
+    }
+
     await enqueueLinks({
         selector: 'li p[class*="link"] a',
         label: LABELS.PRODUCT_PAGE,

--- a/src/routes/product-page.ts
+++ b/src/routes/product-page.ts
@@ -9,6 +9,10 @@ export const handleProductPage = async ({ page, request, log, crawler, parseWith
     await page.waitForLoadState('load');
     const $ = await parseWithCheerio();
 
+    if ($('div.main-wrapper').length === 0) {
+        throw new Error('Redirected the product page');
+    }
+
     const product = parseProduct($, request.url);
     product.prices = parsePrices($);
     product.ratings = parseRatings($);

--- a/src/routes/product-reviews.ts
+++ b/src/routes/product-reviews.ts
@@ -12,6 +12,10 @@ export const handleProductReviews = async ({ request, page, log, crawler, parseW
     await page.waitForLoadState('load');
     const $ = await parseWithCheerio();
 
+    if ($('div.main-wrapper').length === 0) {
+        throw new Error('Redirected the product page');
+    }
+
     if (!product.reviews) product.reviews = [];
 
     const limit = !maxReviews ? null : maxReviews - product.reviews.length;


### PR DESCRIPTION
This pull request addresses an issue where certain anti-scraping measures were causing zero result runs. The changes focus on detecting anti-scraping behavior and retrying the request if redirected.

The key changes include:

- Added a check to detect redirection from the search page and retry the request if necessary.
- Added a check to detect redirection from the product and review pages and retry the request if necessary.

These changes should help improve the reliability and robustness of the scraping process by handling common anti-scraping techniques more effectively.